### PR TITLE
Create Github Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Bug Report
 about: Create a report to help us improve
 title: '[Bug report] title_goes_here'
 labels: 'bug'
@@ -7,32 +7,34 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+# Bug Report
+
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+## Desktop (please complete the following information):
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+## Smartphone (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,9 @@ assignees: ''
 ## Describe the bug
 A clear and concise description of what the bug is.
 
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
 ## To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
@@ -19,22 +22,12 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-## Expected behavior
-A clear and concise description of what you expected to happen.
-
 ## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-## Desktop (please complete the following information):
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-## Smartphone (please complete the following information):
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+## Other info
+ - Browser [e.g. Chrome, Firefox, Safari]
+ - Browser Version [e.g. 22]
 
 ## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,12 +22,12 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-## Screenshots
-If applicable, add screenshots to help explain your problem.
-
 ## Other info
- - Browser [e.g. Chrome, Firefox, Safari]
- - Browser Version [e.g. 22]
+- Browser [e.g. Chrome, Firefox, Safari]
+- Browser Version [e.g. 22]
+
+## Screenshots
+ If applicable, add screenshots to help explain your problem.
 
 ## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
+title: '[Bug report] title_goes_here'
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/empty.md
+++ b/.github/ISSUE_TEMPLATE/empty.md
@@ -1,6 +1,6 @@
 ---
 name: Empty template
-about: Empty issue template
+about: If none of the templates don't fit your need
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/empty.md
+++ b/.github/ISSUE_TEMPLATE/empty.md
@@ -1,8 +1,0 @@
----
-name: Empty template
-about: If none of the templates don't fit your need
-title: ''
-labels: ''
-assignees: ''
-
----

--- a/.github/ISSUE_TEMPLATE/empty.md
+++ b/.github/ISSUE_TEMPLATE/empty.md
@@ -1,0 +1,8 @@
+---
+name: Empty template
+about: Empty issue template
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: '[Feature Request] title_goes_here'
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: Feature Request
 about: Suggest an idea for this project
 title: '[Feature Request] title_goes_here'
 labels: 'enhancement'
@@ -7,14 +7,16 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+# Feature Request
+
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest an idea for this project
+about: Suggest an idea for this project (Not for platform requests, use the "Platform Request" template instead)
 title: '[Feature Request] title_goes_here'
 labels: 'enhancement'
 assignees: ''
@@ -9,14 +9,5 @@ assignees: ''
 
 # Feature Request
 
-## Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-## Describe the solution you'd like
-A clear and concise description of what you want to happen.
-
-## Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
-
-## Additional context
-Add any other context or screenshots about the feature request here.
+## What do you want to be added to the IDE?
+Describe the feature you want to be added to the IDE.

--- a/.github/ISSUE_TEMPLATE/platform_request.md
+++ b/.github/ISSUE_TEMPLATE/platform_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest an idea for this project (Not for platform requests, use the "Platform Request" template instead)
+title: '[Platform Request] Add platform_name to the IDE'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+# Feature Request
+
+## What is the platform do you want to be added to the IDE?
+Please put the platform you want to be added to the IDE here
+
+## Is the platform programmable with a high level language?
+Is the platform you want to suggest programmable with a high level programming language (Like C or BASIC)? If you don't know if the platform can be programmable with a high level programming language, you can delete or ignore this selection. Otherwise put a high level programming language that the platform can be programmed with. (Assembly is not a high level programming language but instead low level)

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@ if (window.location.host.endsWith('8bitworkshop.com')) {
           <li><a class="dropdown-item" target="_8bws_about" href="https://8bitworkshop.com/projects">Projects</a></li>
           <li><a class="dropdown-item" target="_8bws_about" href="https://twitter.com/8bitworkshop">Twitter</a></li>
           <li><a class="dropdown-item" target="_8bws_about" href="https://github.com/sehugg/8bitworkshop">GitHub</a></li>
-          <li><a class="dropdown-item" target="_8bws_about" href="https://github.com/sehugg/8bitworkshop/issues/new">Report an Issue</a></li>
+          <li><a class="dropdown-item" target="_8bws_about" href="https://github.com/sehugg/8bitworkshop/issues/new/choose">Report an Issue</a></li>
         </ul>
       </li>
       <!--


### PR DESCRIPTION
The issue templates are not the best but can be expanded. The issue templates added:

- Bug Report
- Feature Request
- Platform Request

I also changed the *Report an issue* to the *about* sub menu on the IDE so it asks the user what template they want to use or if they want to use an empty one.