### PR TITLE
Adding missing tsconfig.json for tools

### DIFF
--- a/src/tools/tsconfig.json
+++ b/src/tools/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../../gen/platform"
+  },
+  "references": [
+    { "path": "../common" },
+    { "path": "../machine" },
+    { "path": "../ide" },
+  ],
+  "include": [
+    "**/*.ts"
+  ]
+}


### PR DESCRIPTION
Looks like this was missed from the last commit (?)  
`npm run build` fails without it.