### PR TITLE
Update link to MSX2 Technical Handbook in msx.ts

### DIFF
--- a/src/platform/msx.ts
+++ b/src/platform/msx.ts
@@ -3,7 +3,7 @@ import { MSX1 } from "../machine/msx";
 import { Platform, BaseZ80MachinePlatform } from "../common/baseplatform";
 import { PLATFORMS } from "../common/emu";
 
-// https://www.konamiman.com/msx/msx-e.html#msx2th
+// https://github.com/Konamiman/MSX2-Technical-Handbook
 // https://www.msx.org/wiki/MSX_Cartridge_slot
 // http://map.grauw.nl/resources/msx_io_ports.php
 // https://openmsx.org/manual/setup.html


### PR DESCRIPTION
Konamiman originally published his transcript of MSX2 Technical Handbook in the form of text files in his web site, but has later converted it to Markdown files hosted in a dedicated GitHub repository. This pull request changes the link in `msx.ts` from the old text files to the dedicated repository, much easier to read and link.