### PR TITLE
Fix cc65 URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The IDE uses custom forks for many of these, found at https://github.com/sehugg?
 
 ### Compilers
 
-* https://www.cc65.org/
+* https://cc65.github.io/
 * http://sdcc.sourceforge.net/
 * http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html
 * https://github.com/batari-Basic/batari-Basic


### PR DESCRIPTION
On https://github.com/sehugg/awesome-8bitgamedev#compilers there's the correct URL, but here's still the 7 years old one.