### PR TITLE
Fix ZX sprite rendering

### DIFF
--- a/presets/zx/cosmic.c
+++ b/presets/zx/cosmic.c
@@ -142,7 +142,7 @@ byte render_sprite(const byte* src, byte x, byte y, byte op) {
         case OP_XOR:   result |= (*dest++ ^= next); break;
         case OP_ERASE: *dest++ &= ~next; break;
       }
-      rest = data << (7-xs);	// save leftover bits
+      rest = data << (8-xs);	// save leftover bits
     }
     // compute final byte operation
     switch (op) {


### PR DESCRIPTION
Fix for the ZX render_sprite routine. When calculating the `rest` of the bits to carry over to the next byte the calculation was done using 7 rather than 8. This caused the sprites to have small artifacts as they move horizontally.