### PR TITLE
Apple2: Allow uploaded firmware ROM replacement

### DIFF
--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -119,8 +119,6 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
   constructor() {
     super();
     this.loadBIOS(new lzgmini().decode(stringToByteArray(atob(APPLEIIGO_LZG))));
-    this.ram[0xbf00] = 0x4c; // fake DOS detect for C
-    this.ram[0xbf6f] = 0x01; // fake DOS detect for C
     this.connectCPUMemoryBus(this);
   }
   saveState() : AppleIIState {
@@ -167,6 +165,8 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
       this.bios = Uint8Array.from(data);
       this.bios[0xD39A - (0x10000 - this.bios.length)] = 0x60;  // $d39a = RTS
       this.ram.set(this.bios, 0x10000 - this.bios.length);
+      this.ram[0xbf00] = 0x4c; // fake DOS detect for C
+      this.ram[0xbf6f] = 0x01; // fake DOS detect for C
   }
   loadROM(data) {
     if (data.length == 35*16*256) { // is it a disk image?

--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -120,6 +120,11 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
     super();
     this.loadBIOS(new lzgmini().decode(stringToByteArray(atob(APPLEIIGO_LZG))));
     this.connectCPUMemoryBus(this);
+    // This line is inappropriate for real ROMs, but was there for
+    // the APPLE][GO ROM, so keeping it only in the constructor, for
+    // that special case (in case it really is important for this
+    // address to be an RTS).
+    this.bios[0xD39A - (0x10000 - this.bios.length)] = 0x60;  // $d39a = RTS
   }
   saveState() : AppleIIState {
     // TODO: automagic
@@ -163,7 +168,6 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
           console.log("will load BIOS to end of memory anyway...");
       }
       this.bios = Uint8Array.from(data);
-      this.bios[0xD39A - (0x10000 - this.bios.length)] = 0x60;  // $d39a = RTS
       this.ram.set(this.bios, 0x10000 - this.bios.length);
       this.ram[0xbf00] = 0x4c; // fake DOS detect for C
       this.ram[0xbf6f] = 0x01; // fake DOS detect for C

--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -182,6 +182,8 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
     this.auxRAMselected = false;
     this.auxRAMbank = 1;
     this.writeinhibit = true;
+    this.ram.fill(0, 0x300, 0x400); // Clear soft-reset vector
+                                    // (force hard reset)
     this.skipboot();
   }
   skipboot() {

--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -130,9 +130,13 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
     this.kbdlatch = s.kbdlatch;
   }
   loadBIOS(data, title?) {
+      if (data.length != 0x3000) {
+          console.log(`apple2 loadBIOS !!!WARNING!!!: BIOS wants length 0x3000, but BIOS '${title}' has length 0x${data.length.toString(16)}`);
+          console.log("will load BIOS to end of memory anyway...");
+      }
       this.bios = Uint8Array.from(data);
-      this.bios[0x39a] = 0x60; // $d39a = RTS
-      this.ram.set(this.bios, 0xd000);
+      this.bios[0xD39A - (0x10000 - this.bios.length)] = 0x60;  // $d39a = RTS
+      this.ram.set(this.bios, 0x10000 - this.bios.length);
   }
   loadROM(data) {
     if (data.length == 35*16*256) { // is it a disk image?
@@ -167,7 +171,7 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS {
          return this.ram[address];
       } else if (address >= 0xd000) {
          if (!this.auxRAMselected)
-            return this.bios[address - 0xd000];
+            return this.bios[address - (0x10000 - this.bios.length)];
          else if (address >= 0xe000)
             return this.ram[address];
          else


### PR DESCRIPTION
Allows the user to upload a file named "apple2.rom" (need not be part of the current project), for the potential to provide a more realistic Apple ][+ environment.