### PR TITLE
Grab control-key keyboard input

### DIFF
--- a/src/common/emu.ts
+++ b/src/common/emu.ts
@@ -53,7 +53,7 @@ export enum KeyFlags {
 export function _setKeyboardEvents(canvas:HTMLElement, callback:KeyboardCallback) {
   canvas.onkeydown = (e) => {
     callback(e.which, 0, KeyFlags.KeyDown|_metakeyflags(e));
-    if (e.which == 8 || e.which == 9 || e.which == 27) { // eat backspace, tab, escape keys
+    if (e.ctrlKey || e.which == 8 || e.which == 9 || e.which == 27) { // eat backspace, tab, escape keys
       e.preventDefault();
     }
   };

--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -303,6 +303,18 @@ export class AppleII extends BasicScanlineMachine {
         case 39: code=21; break; // right
         case 38: code=11; break; // up
         case 40: code=10; break; // down
+        default:
+          if (flags & KeyFlags.Ctrl) {
+            code = key;
+            if (code >= 0x61 && code <= 0x7a)
+              code -= 32;
+            if (key >= 65 && code < 65+26) {
+                code -= 64; // ctrl
+            }
+            else {
+              code = 0;
+            }
+          }
       }
       if (code)
         this.kbdlatch = (code | 0x80) & 0xff;

--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -296,7 +296,14 @@ export class AppleII extends BasicScanlineMachine {
     } else if (flags & KeyFlags.KeyDown) {
       code = 0;
       switch (key) {
-        case 8:  code=8; break; // left
+        case 8:
+          code=8; // left
+          if (flags & KeyFlags.Ctrl) {
+            // (possibly) soft reset
+            this.cpu.reset();
+            return;
+          }
+          break;
         case 13: code=13; break; // return
         case 27: code=27; break; // escape
         case 37: code=8; break; // left


### PR DESCRIPTION
Here's my go at grabbing Ctrl+key combinations more effectively (wasn't previously working). It also adds Ctrl+BkSpace as a "RESET" key for soft resets (forced-hard resets should continue to use the clickable reset button in the debug/stepwise controls).

It's unclear to me how appropriate the change to `RasterVideo`'s keyboard handling in emu.ts may be. Like, do we want to unconditionally grab all Ctrl+key combinations if we're emulating, e.g., an NES, or other non-computer device that may not care about fine-grained keyboard input?

What about extending the `RasterVideo` class, something like `RasterVideoWithKeyboard`, that adds this sort of broader application of `e.preventDefault()`, leaving the original behavior in the original `RasterVideo` class? Then the apple2 platform (and probably other computer+keyboard platforms) could ensure that `this.video` is populated with the `RasterVideoWithKeyboard`