### PR TITLE
editor cursor appears where it was in files

### DIFF
--- a/src/ide/windows.ts
+++ b/src/ide/windows.ts
@@ -63,6 +63,7 @@ export class ProjectWindows {
       this.activediv = div;
       this.activewnd = wnd;
       $(div).show();
+      $('textarea', div).focus();
       this.refresh(true); // needed to tell asset editor 1st time running, but that's bad
       this.refreshErrors();
       wnd.setVisible && wnd.setVisible(true);


### PR DESCRIPTION
This is a quality-of-life one-liner patch.

When the user navigates between files, focus on the file editor is lost. The user can see a selection when they return to the file, but due to the textarea being unfocused the user will have to remake the selection. With this patch the user will be able to look at another file and then return to the one they are editing without finding their place again and clicking the cursor into place with a mouse before typing.