### PR TITLE
Added option to export debug symbols for Mesen

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@ if (window.location.host.endsWith('8bitworkshop.com')) {
           <li><a class="dropdown-item" href="#" id="item_download_rom">Download ROM Image</a></li>
           <li><a class="dropdown-item" href="#" id="item_download_zip">Download Project as ZIP</a></li>
           <li><a class="dropdown-item" href="#" id="item_download_allzip">Download All Changes as ZIP</a></li>
+          <li><a class="dropdown-item" href="#" id="item_download_sym">Download Debug Symbols (.mlb)</a></li>
         </ul>
       </li>
       <li class="dropdown dropdown-submenu">


### PR DESCRIPTION
This is something I've needed for so long. Sometimes the built-in debugger just doesn't cut it and using an external debugger without having access to symbols is hell. Personally this would be a great time saver.