### PR TITLE
Restore Vectrex platform menu item

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,9 +153,7 @@ body {
                <li><a class="dropdown-item" href="?platform=atari8-5200">Atari 5200</a></li>
                <li><a class="dropdown-item" href="?platform=atari7800">Atari 7800</a></li>
                <li><a class="dropdown-item" href="?platform=pce">PC Engine</a></li>
-               <!--
                <li><a class="dropdown-item" href="?platform=vectrex">Vectrex</a></li>
-               -->
              </ul>
           </li>
           <li class="dropdown dropdown-submenu">


### PR DESCRIPTION
Restores Vectrex platform which appears to have been inadvertently commented out in `ef5bcd3c9`

Note, Vectrex is not documented on https://8bitworkshop.com/docs/platforms/index.html