### PR TITLE
Always make buildgrammars before running tsc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ tsweb: submodules node_modules
 	npm run esbuild-clean
 	(ip addr || ifconfig) | grep inet
 	trap 'kill 0' EXIT; \
+	make buildgrammars; \
 	$(TSC) -w --preserveWatchOutput & \
 	make watchgrammars & \
 	npm run esbuild-worker -- --watch & \


### PR DESCRIPTION
Avoid race condition between `make watchgrammars` and `$(TSC) -w --preserveWatchOutput` on first run of `make tsweb` (when `gen/` is emtpy).