### PR TITLE
Less chatty refreshDebugState

### DIFF
--- a/src/ide/views/editors.ts
+++ b/src/ide/views/editors.ts
@@ -541,11 +541,7 @@ export class SourceEditor implements ProjectView {
       return;
     }
 
-    // TODO: remove after compilation
-    this.clearCurrentLine(moveCursor);
-    if (line) {
-      this.setCurrentLine(line, moveCursor);
-    }
+    this.setCurrentLine(line, moveCursor);
   }
 
   refreshListing() {

--- a/src/ide/views/editors.ts
+++ b/src/ide/views/editors.ts
@@ -536,10 +536,13 @@ export class SourceEditor implements ProjectView {
   }
 
   refreshDebugState(moveCursor: boolean) {
-    // TODO: only if line changed
+    var line = this.getActiveLine();
+    if (!line && !this.currentDebugLine && !moveCursor) {
+      return;
+    }
+
     // TODO: remove after compilation
     this.clearCurrentLine(moveCursor);
-    var line = this.getActiveLine();
     if (line) {
       this.setCurrentLine(line, moveCursor);
     }


### PR DESCRIPTION
- Avoid unnecessarily update the current PC marker
  every tick when there's nothing to update, avoiding
  unnecessary EditorView.updateListener invocations
- Remove redundant clearCurrentLine call and
  conditional check that is already in `setCurrenLine`
