### PR TITLE
Fix unwanted scroll on window blur

### DIFF
--- a/src/ide/views/editors.ts
+++ b/src/ide/views/editors.ts
@@ -480,8 +480,8 @@ export class SourceEditor implements ProjectView {
         effects: [
           currentPcMarker.set.of(line.line),
           currentPc.effect.of(line.line),
-          // Optional: follow the execution point
-          EditorView.scrollIntoView(this.editor.state.doc.line(line.line).from, { y: "center" }),
+          // Follow the execution point when stepping/hitting breakpoints.
+          ...(moveCursor ? [EditorView.scrollIntoView(this.editor.state.doc.line(line.line).from, { y: "center" })] : []),
         ]
       });
     }


### PR DESCRIPTION
Prevent unwanted viewport scroll
in setCurrentLine when the tab
loses focus. Only call scrollIntoView
when moveCursor is true.