### PR TITLE
apple2: allow arbitrary start addresses for DOS 3.3 binaries

### DIFF
--- a/presets/apple2/dos33bin.a
+++ b/presets/apple2/dos33bin.a
@@ -9,7 +9,7 @@
 ; --------------------------------------------------
 ; Set PGM_START to desired start of program execution
 ; - PGM_START must be less than $C000
-; - PGM_START + SIZE must be less than $13000
+; - PGM_START + PGM_LENGTH must be less than $13000
 ; --------------------------------------------------
 PGM_START    equ     $2000
 PGM_LENGTH   equ     PGM_END - PGM_START

--- a/src/machine/apple2.ts
+++ b/src/machine/apple2.ts
@@ -195,8 +195,7 @@ export class AppleII extends BasicScanlineMachine implements AcceptsBIOS, Accept
             const hdrOrigin = this.rom[0] | (this.rom[1] << 8);
             const size = this.rom[2] | (this.rom[3] << 8);
             let isPlausible = hdrOrigin < 0xc000
-               && hdrOrigin + size < 0x13000
-               && (hdrOrigin == 0x803 || (hdrOrigin & 0xff) == 0);
+               && hdrOrigin + size < 0x13000;
             if (size == data.length - 4 && isPlausible) {
                this.LOAD_BASE = hdrOrigin;
                this.HDR_SIZE = 4;


### PR DESCRIPTION
Remove requirement for start address to be $0803 or multiple of 256

Follow up on #204 which removed the requirement for AppleSingle files.
This PR applies the same update, but for DOS 3.3 binaries.
